### PR TITLE
fix(mcdu): Remove Degree Symbol from GND TEMP INIT A Page

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MenuPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MenuPage.js
@@ -141,6 +141,9 @@ class CDUMenuPage {
             }, mcdu.getDelaySwitchPage());
         };
         mcdu.onPerf = () => {
+            if (mcdu.currentFlightPhase === FmgcFlightPhases.DONE) {
+                mcdu.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.PREFLIGHT);
+            }
             const cur = mcdu.page.Current;
             setTimeout(() => {
                 if (mcdu.page.Current === cur) {
@@ -149,6 +152,9 @@ class CDUMenuPage {
             }, mcdu.getDelaySwitchPage());
         };
         mcdu.onInit = () => {
+            if (mcdu.currentFlightPhase === FmgcFlightPhases.DONE) {
+                mcdu.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.PREFLIGHT);
+            }
             const cur = mcdu.page.Current;
             setTimeout(() => {
                 if (mcdu.page.Current === cur) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -2278,10 +2278,6 @@ class FMCMainDisplay extends BaseAirliners {
             this.addNewMessage(NXSystemMessages.entryOutOfRange);
             return false;
         }
-        if (fl > Math.floor(Simplane.getAltitude() / 100) && phase === FmgcFlightPhases.DESCENT) {
-            this.addNewMessage(NXSystemMessages.entryOutOfRange);
-            return false;
-        }
 
         if (fl <= 0 || fl > this.maxCruiseFL) {
             this.addNewMessage(NXSystemMessages.entryOutOfRange);
@@ -2295,7 +2291,11 @@ class FMCMainDisplay extends BaseAirliners {
         this.cruiseTemperature = undefined;
         this.updateConstraints();
 
-        if (phase === FmgcFlightPhases.APPROACH || phase === FmgcFlightPhases.GOAROUND) {
+        const acFl = Math.floor(Simplane.getAltitude() / 100);
+
+        if (acFl > fl && (phase === FmgcFlightPhases.CLIMB || phase === FmgcFlightPhases.DESCENT || phase === FmgcFlightPhases.APPROACH)) {
+            this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.CRUISE);
+        } else if (acFl < fl && (phase === FmgcFlightPhases.DESCENT || phase === FmgcFlightPhases.APPROACH)) {
             this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.CLIMB);
         }
 
@@ -2639,35 +2639,19 @@ class FMCMainDisplay extends BaseAirliners {
     }
 
     tryGoInApproachPhase() {
-        if (this.currentFlightPhase === FmgcFlightPhases.CLIMB) {
+        if (
+            this.currentFlightPhase === FmgcFlightPhases.PREFLIGHT ||
+            this.currentFlightPhase === FmgcFlightPhases.TAKEOFF ||
+            this.currentFlightPhase === FmgcFlightPhases.DONE
+        ) {
+            return false;
+        }
+
+        if (this.currentFlightPhase !== FmgcFlightPhases.APPROACH) {
             this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.APPROACH);
-            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
-            SimVar.SetSimVarValue("L:A32NX_GOAROUND_PASSED", "bool", 0);
-            return true;
         }
-        if (this.currentFlightPhase === FmgcFlightPhases.CRUISE) {
-            this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.APPROACH);
-            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
-            SimVar.SetSimVarValue("L:A32NX_GOAROUND_PASSED", "bool", 0);
-            return true;
-        }
-        if (this.currentFlightPhase === FmgcFlightPhases.DESCENT) {
-            this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.APPROACH);
-            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
-            SimVar.SetSimVarValue("L:A32NX_GOAROUND_PASSED", "bool", 0);
-            return true;
-        }
-        if (this.currentFlightPhase === FmgcFlightPhases.GOAROUND) {
-            this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.APPROACH);
-            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
-            SimVar.SetSimVarValue("L:A32NX_GOAROUND_PASSED", "bool", 0);
-            return true;
-        }
-        if (this.currentFlightPhase === FmgcFlightPhases.APPROACH) {
-            SimVar.SetSimVarValue("L:A32NX_GOAROUND_PASSED", "bool", 0);
-            return true;
-        }
-        return false;
+
+        return true;
     }
 
     connectIlsFrequency(_freq) {


### PR DESCRIPTION
## Summary of Changes
Remove Degree Symbol from GND TEMP INIT A Page

## Screenshots (if necessary)
Before: 
![Microsoft Flight Simulator - 1 14 5 0 15_03_2021 13_02_31](https://user-images.githubusercontent.com/77690813/111824612-65d02d00-8921-11eb-921d-0fbc1be2a4bd.png)
After:
![Microsoft Flight Simulator - 1 14 5 0 15_03_2021 13_02_31_LI](https://user-images.githubusercontent.com/77690813/111824655-741e4900-8921-11eb-8642-e07fd9ba2b16.jpg)

## References
![initapgpgpg](https://user-images.githubusercontent.com/77690813/111824796-9ca64300-8921-11eb-928e-b03bac318a97.jpg)
The degree symbol will automatically generate after entering the temprature.

## Additional context
Discord username (if different from GitHub): Wesley#0008

## Testing instructions
Load in and check for visual bugs on the INT A page

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
2. Click on the **Checks** tab on the PR
3. On the left side, click on the bottom **PR** tab
4. Click on the **A32NX** download link at the bottom of the page
